### PR TITLE
add function for parsing md string to array

### DIFF
--- a/README.md
+++ b/README.md
@@ -378,6 +378,26 @@ caramel color
 aspartame
 ```
 
+### Reading and writing to / from strings and arrays
+In addition to writing and reading directly to and from .md files, you can also manipulate md strings directly, using the following functions:
+#### x_parse_md_string
+Accepts a string of Markdown content, and returns a corresponding PHP associative array, or false on failure.
+##### Parameters
+- string `$s_hd_content` String representing a Markdown document
+- string `$s_line_delimeter` The string marking the boundary between lines in the file. Default is PHP_EOL.
+
+#### x_parse_md_lines
+Accepts an array of Markdown lines, and returns a corresponding PHP associative array, or false on failure.
+##### Parameters
+- array `$a_hd_lines` Array of lines of a Markdown document
+
+#### s_stringify_x
+Accepts a PHP associative array or object, and returns a corresponding Markdown string.
+##### Parameters
+- mixed `$x_data` The associative array or object to be converted.
+- bool `$b_no_shorthand_lists` If true, don't use shorthand "dash" syntax for any lists
+- bool `$b_omit_numeric_array_keys` If true, omit explicit key values for sequential numeric arrays
+
 ## Testing
 - cd to the directory
 - composer install

--- a/src/Hashdown.php
+++ b/src/Hashdown.php
@@ -200,6 +200,17 @@ class Hashdown {
   }
 
   /**
+   * Parses a string of Markdown content into a PHP associative array.
+   *
+   * @param string $s_hd_content String representing a Markdown document
+   * @param string $s_line_delimeter The string marking the boundary between lines in the file. Default is PHP_EOL.
+   * @return array|false The associative array representation of the Markdown content, or false on failure.
+   */
+  static function x_parse_md_string ( string $a_hd_content, string $s_line_delimeter = PHP_EOL ) {
+    return self::x_parse_md_lines ( explode($s_line_delimeter, $a_hd_content) );
+  }
+
+  /**
    * Parses an array of Markdown lines into a PHP associative array.
    *
    * @param array $a_hd_lines Array of lines of a Markdown document

--- a/tests/HashdownTest.php
+++ b/tests/HashdownTest.php
@@ -14,6 +14,20 @@ class HashdownTest extends TestCase {
   //   file_put_contents( __DIR__ . '/data/0_tgt.json', json_encode($x_from_md, JSON_PRETTY_PRINT) );
   //   $this->assertSame('hello', 'hello', 'not the same');
   // }
+  public function testParseString () {
+    $this->assertParsedMdMatchesString('blank', '');
+    $this->assertParsedMdMatchesString('single-scalar-value', 'lorem ipsum');
+    $this->assertParsedMdMatchesString('single-scalar-value-literal', '# lorem ipsum' . PHP_EOL . PHP_EOL . '## lorem ipsum');
+    $this->assertParsedMdMatchesString('literals-within-literals', rtrim(file_get_contents(__DIR__ . '/data/literals-within-literals.txt')));
+
+    $this->assertParsedMdMatchesCorrespondingJson('todo-list', true);
+    $this->assertParsedMdMatchesCorrespondingJson('list-of-paragraphs', true);
+
+    $this->assertParsedMdMatchesCorrespondingJson('person', true);
+    $this->assertParsedMdMatchesCorrespondingJson('person-first-last-name', true);
+    $this->assertParsedMdMatchesCorrespondingJson('blank-key-values', true);
+    $this->assertParsedMdMatchesCorrespondingJson('page-builder', true);
+  }
   public function testParseFile () {
     $this->assertParsedMdMatchesString('blank', '');
     $this->assertParsedMdMatchesString('single-scalar-value', 'lorem ipsum');
@@ -29,8 +43,18 @@ class HashdownTest extends TestCase {
     $this->assertParsedMdMatchesCorrespondingJson('page-builder');
   }
 
-  private function assertParsedMdMatchesCorrespondingJson(string $s_filename) {
-    $x_from_md = Hashdown::x_read_file( __DIR__ . '/data/' . $s_filename . '.md' );
+  private function x_get_parsed_data_from_md_file(string $s_file_path, bool $b_get_file_contents_as_string = false) {
+    if ($b_get_file_contents_as_string) {
+      return Hashdown::x_parse_md_string( file_get_contents($s_file_path) );
+    }
+    else {
+      return Hashdown::x_read_file( $s_file_path );
+    }
+  }
+
+  private function assertParsedMdMatchesCorrespondingJson(string $s_filename, bool $b_get_file_contents_as_string = false) {
+    $x_from_md = $this->x_get_parsed_data_from_md_file( __DIR__ . '/data/' . $s_filename . '.md', $b_get_file_contents_as_string);
+
     $a_from_json = json_decode( file_get_contents( __DIR__ . '/data/' . $s_filename . '.json'), true );
     // file_put_contents( __DIR__ . '/tmp/log_' . $s_filename . '_json.txt', print_r($x_from_json, 1) );
     // file_put_contents( __DIR__ . '/tmp/log_' . $s_filename . '_md.txt', print_r($x_from_md, 1) );
@@ -42,8 +66,8 @@ class HashdownTest extends TestCase {
     );
   }
 
-  private function assertParsedMdMatchesString(string $s_filename, string $s_expected_value) {
-    $x_from_md = Hashdown::x_read_file( __DIR__ . '/data/' . $s_filename . '.md' );
+  private function assertParsedMdMatchesString(string $s_filename, string $s_expected_value, bool $b_get_file_contents_as_string = false) {
+    $x_from_md = $this->x_get_parsed_data_from_md_file( __DIR__ . '/data/' . $s_filename . '.md', $b_get_file_contents_as_string);
     $this->assertSame(
       $s_expected_value,
       $x_from_md,


### PR DESCRIPTION
Adds `x_parse_md_string` to allow converting markdown content directly from a string, rather than an array or file.

Addresses issue #2 